### PR TITLE
Update llms-txt-php version constraint to allow 3.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     "require": {
         "php": ">=8.1",
         "ext-curl": "*",
-        "stolt/llms-txt-php": "^2.0",
+        "stolt/llms-txt-php": "^2.0 || ^3.0",
         "symfony/console": "^7.3"
     },
     "require-dev": {


### PR DESCRIPTION

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR updates the `stolt/llms-txt-php` dependency version constraint in `composer.json` to allow both version 2.x and 3.x, enabling the package to be compatible with the newer major version while maintaining backward compatibility with the current version.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `composer.json` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->